### PR TITLE
🔗 :: (#110) 교실이동 수락 특정 층 레이아웃 수정

### DIFF
--- a/Projects/Feature/AcceptFeature/Sources/Scene/AcceptView.swift
+++ b/Projects/Feature/AcceptFeature/Sources/Scene/AcceptView.swift
@@ -16,7 +16,7 @@ public struct AcceptView: View {
     @Environment(\.dismiss) var dismiss
     @State private var isApplyBottomSheetPresented = false
     @State private var selectedOption: ApplicationType = .outgoing
-    @State private var selectedFloor: Int = 2
+    @State private var selectedFloor: Int = 3
     @State private var showApprovePopup = false
     @State private var showRejectPopup = false
     let store: StoreOf<AcceptReducer>
@@ -67,7 +67,7 @@ public struct AcceptView: View {
                     ScrollViewReader { proxy in
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack(spacing: 8) {
-                                ForEach(1...5, id: \.self) { floor in
+                                ForEach(2...4, id: \.self) { floor in
                                     Button {
                                         selectedFloor = floor
                                         viewStore.send(.fetchApplicationsByFloor(floor: floor))
@@ -91,12 +91,12 @@ public struct AcceptView: View {
                             .padding(.horizontal, 24)
                         }
                         .onAppear {
-                            proxy.scrollTo(2, anchor: .leading)
+                            proxy.scrollTo(3, anchor: .center)
                         }
                         .onChange(of: selectedOption) { newValue in
                             if newValue == .classroomMove {
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                    proxy.scrollTo(2, anchor: .leading)
+                                    proxy.scrollTo(3, anchor: .center)
                                 }
                             }
                         }

--- a/Projects/Feature/AcceptFeature/Sources/Scene/AcceptView.swift
+++ b/Projects/Feature/AcceptFeature/Sources/Scene/AcceptView.swift
@@ -16,7 +16,7 @@ public struct AcceptView: View {
     @Environment(\.dismiss) var dismiss
     @State private var isApplyBottomSheetPresented = false
     @State private var selectedOption: ApplicationType = .outgoing
-    @State private var selectedFloor: Int = 1
+    @State private var selectedFloor: Int = 2
     @State private var showApprovePopup = false
     @State private var showRejectPopup = false
     let store: StoreOf<AcceptReducer>
@@ -64,31 +64,44 @@ public struct AcceptView: View {
                     .padding(.horizontal, 24)
 
                 if selectedOption == .classroomMove {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 8) {
-                            ForEach(1...5, id: \.self) { floor in
-                                Button {
-                                    selectedFloor = floor
-                                    viewStore.send(.fetchApplicationsByFloor(floor: floor))
-                                } label: {
-                                    Text("\(floor)층")
-                                        .pickText(
-                                            type: .body1,
-                                            textColor: selectedFloor == floor ? .Primary.primary500 : .Gray.gray600
-                                        )
-                                        .frame(width: 114, height: 32)
-                                        .background(
-                                            selectedFloor == floor
-                                            ? Color.Primary.primary50
-                                            : Color.clear
-                                        )
-                                        .cornerRadius(8)
+                    ScrollViewReader { proxy in
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(1...5, id: \.self) { floor in
+                                    Button {
+                                        selectedFloor = floor
+                                        viewStore.send(.fetchApplicationsByFloor(floor: floor))
+                                    } label: {
+                                        Text("\(floor)층")
+                                            .pickText(
+                                                type: .body1,
+                                                textColor: selectedFloor == floor ? .Primary.primary500 : .Gray.gray600
+                                            )
+                                            .frame(width: 114, height: 32)
+                                            .background(
+                                                selectedFloor == floor
+                                                ? Color.Primary.primary50
+                                                : Color.clear
+                                            )
+                                            .cornerRadius(8)
+                                    }
+                                    .id(floor)
+                                }
+                            }
+                            .padding(.horizontal, 24)
+                        }
+                        .onAppear {
+                            proxy.scrollTo(2, anchor: .leading)
+                        }
+                        .onChange(of: selectedOption) { newValue in
+                            if newValue == .classroomMove {
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                    proxy.scrollTo(2, anchor: .leading)
                                 }
                             }
                         }
-                        .padding(.horizontal, 24)
+                        .padding(.top, 16)
                     }
-                    .padding(.top, 16)
                 }
 
                 HStack(spacing: 0) {

--- a/Projects/Feature/AcceptFeature/Sources/Scene/AcceptView.swift
+++ b/Projects/Feature/AcceptFeature/Sources/Scene/AcceptView.swift
@@ -67,7 +67,7 @@ public struct AcceptView: View {
                     ScrollViewReader { proxy in
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack(spacing: 8) {
-                                ForEach(2...4, id: \.self) { floor in
+                                ForEach([1, 2, 3, 4, 5], id: \.self) { floor in
                                     Button {
                                         selectedFloor = floor
                                         viewStore.send(.fetchApplicationsByFloor(floor: floor))

--- a/Projects/Feature/ClassroomMoveListFeature/Sources/Scene/ClassroomMoveListView.swift
+++ b/Projects/Feature/ClassroomMoveListFeature/Sources/Scene/ClassroomMoveListView.swift
@@ -43,29 +43,35 @@ public struct ClassroomMoveListView: View {
                         .padding(.horizontal, 24)
 
                     if viewStore.currentType == .floor {
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 8) {
-                                ForEach([2, 3, 4], id: \.self) { floor in
-                                    Button {
-                                        selectedFloor = floor
-                                        viewStore.send(.fetchFloor(floor))
-                                    } label: {
-                                        Text("\(floor)층")
-                                            .pickText(
-                                                type: .body1,
-                                                textColor: selectedFloor == floor ? .Primary.primary500 : .Gray.gray600
-                                            )
-                                            .frame(width: 114, height: 32)
-                                            .background(
-                                                selectedFloor == floor
-                                                ? Color.Primary.primary50
-                                                : Color.clear
-                                            )
-                                            .cornerRadius(8)
+                        ScrollViewReader { proxy in
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 8) {
+                                    ForEach([1, 2, 3, 4, 5], id: \.self) { floor in
+                                        Button {
+                                            selectedFloor = floor
+                                            viewStore.send(.fetchFloor(floor))
+                                        } label: {
+                                            Text("\(floor)층")
+                                                .pickText(
+                                                    type: .body1,
+                                                    textColor: selectedFloor == floor ? .Primary.primary500 : .Gray.gray600
+                                                )
+                                                .frame(width: 114, height: 32)
+                                                .background(
+                                                    selectedFloor == floor
+                                                    ? Color.Primary.primary50
+                                                    : Color.clear
+                                                )
+                                                .cornerRadius(8)
+                                        }
+                                        .id(floor)
                                     }
                                 }
+                                .padding(.horizontal, 24)
                             }
-                            .padding(.horizontal, 24)
+                            .onAppear {
+                                proxy.scrollTo(3, anchor: .center)
+                            }
                         }
                         .padding(.top, 16)
                     } else {


### PR DESCRIPTION
## 개요
- 교실이동 수락 특정 층 레이아웃 수정
## 작업사항
- 교실이동 수락 특정 층 레이아웃 수정 2,3,4
## UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 기본 선택 층이 3층으로 변경되었습니다.
  * 수평 층 선택기가 초기 실행 시 3층을 중앙에 표시하는 자동 스크롤을 지원합니다.

* **Bug Fixes / 개선**
  * 층 선택기 스크롤 동작과 내부 패딩이 개선되어 더 안정적이고 매끄러운 스크롤 경험을 제공합니다.
  * 층 범위가 1–5로 조정되어 전체 범위 선택이 반영됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->