### PR TITLE
🔗 :: (#129) 수락 버튼 위치 바꾸기

### DIFF
--- a/Projects/Feature/AcceptFeature/Sources/Component/ActionButton/AcceptActionButtons.swift
+++ b/Projects/Feature/AcceptFeature/Sources/Component/ActionButton/AcceptActionButtons.swift
@@ -9,12 +9,12 @@ struct AcceptActionButtons: View {
     var body: some View {
         HStack(spacing: 8) {
             Button {
-                onAccept()
+                onReject()
             } label: {
-                Text("수락")
+                Text("거절")
                     .pickText(type: .body2, textColor: .Normal.white)
                     .frame(width: 65, height: 34)
-                    .background(Color.Primary.primary900)
+                    .background(Color.Error.error)
                     .cornerRadius(8)
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)
@@ -24,12 +24,12 @@ struct AcceptActionButtons: View {
             .disabled(!isEnabled)
 
             Button {
-                onReject()
+                onAccept()
             } label: {
-                Text("거절")
+                Text("수락")
                     .pickText(type: .body2, textColor: .Normal.white)
                     .frame(width: 65, height: 34)
-                    .background(Color.Error.error)
+                    .background(Color.Primary.primary900)
                     .cornerRadius(8)
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)

--- a/Projects/Feature/HomeFeature/Sources/Component/Accept/AcceptCell.swift
+++ b/Projects/Feature/HomeFeature/Sources/Component/Accept/AcceptCell.swift
@@ -27,21 +27,21 @@ struct AcceptCell: View {
             Spacer()
 
             HStack(spacing: 8) {
-                Button(action: onAccept) {
-                    Text("수락")
-                        .pickText(type: .body2, textColor: .Normal.white)
-                        .padding(.horizontal, 15)
-                        .padding(.vertical, 8)
-                        .background(Color.Primary.primary500)
-                        .cornerRadius(8)
-                }
-                
                 Button(action: onReject) {
                     Text("거절")
                         .pickText(type: .body2, textColor: .Normal.white)
                         .padding(.horizontal, 15)
                         .padding(.vertical, 8)
                         .background(Color.Error.error)
+                        .cornerRadius(8)
+                }
+
+                Button(action: onAccept) {
+                    Text("수락")
+                        .pickText(type: .body2, textColor: .Normal.white)
+                        .padding(.horizontal, 15)
+                        .padding(.vertical, 8)
+                        .background(Color.Primary.primary500)
                         .cornerRadius(8)
                 }
             }


### PR DESCRIPTION
## 개요
수락 버튼 위치 바꾸기

## 작업사항
- 수락 화면에서
- 메인화면에서

## UI
<img width="150" src="https://github.com/user-attachments/assets/3f72c76c-5c4a-439d-8a07-d913734568c9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 수락 및 거절 버튼의 위치, 색상, 라벨이 올바르게 조정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->