### PR TITLE
refactor :: [#135] TCA 1.25 modernization / 2.0 prep rollout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ Tuist/Dependencies
 
 /XCConfig
 Projects/App/Resources/Firebase/
+.omx/
+.omc/

--- a/Projects/Feature/BugReport/Project.swift
+++ b/Projects/Feature/BugReport/Project.swift
@@ -39,8 +39,27 @@ let implementationTarget = Target.target(
     sources: ["Sources/**"],
     dependencies: [
         .target(name: "BugReportFeatureInterface"),
+        .Projects.bugReportDomainInterface,
+        .Shared.utility,
+        .SPM.PDS,
         .SPM.NeedleFoundation,
         .SPM.ComposableArchitecture
+    ]
+)
+
+let testTarget = Target.target(
+    name: "BugReportFeatureTests",
+    destinations: env.destination,
+    product: .unitTests,
+    bundleId: "\(env.organizationName).BugReportFeatureTests",
+    deploymentTargets: env.deploymentTargets,
+    infoPlist: .default,
+    sources: ["Tests/**"],
+    dependencies: [
+        .target(name: "BugReportFeature"),
+        .target(name: "BugReportFeatureInterface"),
+        .Projects.bugReportDomainInterface,
+        .Shared.utility
     ]
 )
 
@@ -48,5 +67,5 @@ let project = Project(
     name: "BugReportFeature",
     organizationName: env.organizationName,
     settings: settings,
-    targets: [interfaceTarget, implementationTarget]
+    targets: [interfaceTarget, implementationTarget, testTarget]
 )

--- a/Projects/Feature/BugReport/Sources/BugReportReducer.swift
+++ b/Projects/Feature/BugReport/Sources/BugReportReducer.swift
@@ -6,6 +6,7 @@ import SwiftUI
 import BugReportDomainInterface
 import Combine
 
+@Reducer
 public struct BugReportReducer: Reducer {
     private let uploadBugImagesUseCase: any UploadBugImagesUseCaseProtocol
     private let submitBugReportUseCase: any SubmitBugReportUseCaseProtocol
@@ -18,6 +19,7 @@ public struct BugReportReducer: Reducer {
         self.submitBugReportUseCase = submitBugReportUseCase
     }
 
+    @ObservableState
     public struct State: Equatable {
         public var bugLocation: String = ""
         public var bugDescription: String = ""
@@ -32,37 +34,35 @@ public struct BugReportReducer: Reducer {
         public init() {}
     }
 
-    public enum Action {
-        case bugLocationChanged(String)
-        case bugDescriptionChanged(String)
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
         case imagesSelected([Data])
         case removeImage(Int)
         case submitButtonTapped
         case uploadImagesResponse(TaskResult<[String]>)
         case submitBugReportResponse(TaskResult<Void>)
         case dismissAlert
-        case updateSubmitButtonState
     }
 
-    public var body: some Reducer<State, Action> {
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+
         Reduce { state, action in
             switch action {
-            case let .bugLocationChanged(text):
-                state.bugLocation = text
-                return .send(.updateSubmitButtonState)
-
-            case let .bugDescriptionChanged(text):
-                state.bugDescription = text
-                return .send(.updateSubmitButtonState)
+            case .binding:
+                updateSubmitButtonState(state: &state)
+                return .none
 
             case let .imagesSelected(images):
                 state.selectedImages = images
-                return .send(.updateSubmitButtonState)
+                updateSubmitButtonState(state: &state)
+                return .none
 
             case let .removeImage(index):
                 guard index < state.selectedImages.count else { return .none }
                 state.selectedImages.remove(at: index)
-                return .send(.updateSubmitButtonState)
+                updateSubmitButtonState(state: &state)
+                return .none
 
             case .submitButtonTapped:
                 guard !state.bugLocation.isEmpty && !state.bugDescription.isEmpty else {
@@ -116,6 +116,7 @@ public struct BugReportReducer: Reducer {
                 state.bugLocation = ""
                 state.bugDescription = ""
                 state.selectedImages = []
+                state.isSubmitButtonEnabled = false
                 return .none
 
             case .submitBugReportResponse(.failure):
@@ -128,11 +129,11 @@ public struct BugReportReducer: Reducer {
             case .dismissAlert:
                 state.showAlert = false
                 return .none
-
-            case .updateSubmitButtonState:
-                state.isSubmitButtonEnabled = !state.bugLocation.isEmpty && !state.bugDescription.isEmpty
-                return .none
             }
         }
+    }
+
+    private func updateSubmitButtonState(state: inout State) {
+        state.isSubmitButtonEnabled = !state.bugLocation.isEmpty && !state.bugDescription.isEmpty
     }
 }

--- a/Projects/Feature/BugReport/Sources/Scene/BugReportView.swift
+++ b/Projects/Feature/BugReport/Sources/Scene/BugReportView.swift
@@ -5,7 +5,7 @@ import PhotosUI
 
 public struct BugReportView: View {
     @Environment(\.dismiss) var dismiss
-    let store: StoreOf<BugReportReducer>
+    @Perception.Bindable var store: StoreOf<BugReportReducer>
     @State private var selectedItems: [PhotosPickerItem] = []
     @FocusState private var isDescriptionFocused: Bool
 
@@ -14,31 +14,31 @@ public struct BugReportView: View {
     }
 
     public var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
+        WithPerceptionTracking {
             ZStack {
                 VStack(spacing: 0) {
                     customNavigationBar
 
                     ScrollView {
-                        formContent(viewStore: viewStore)
+                        formContent
                     }
 
-                    submitButton(viewStore: viewStore)
+                    submitButton
                 }
                 .background(Color.Background.background)
                 .navigationBarHidden(true)
                 .toolbar(.hidden, for: .tabBar)
                 
-                if viewStore.showAlert {
+                if store.showAlert {
                     VStack {
                         Spacer()
                         PiCKDisappearAlert(
-                            successType: viewStore.alertSuccessType,
-                            message: viewStore.alertMessage
+                            successType: store.alertSuccessType,
+                            message: store.alertMessage
                         )
                         .onDisappear {
-                            viewStore.send(.dismissAlert)
-                            if viewStore.shouldDismiss {
+                            store.send(.dismissAlert)
+                            if store.shouldDismiss {
                                 dismiss()
                             }
                         }
@@ -65,37 +65,31 @@ public struct BugReportView: View {
         .background(Color.Background.background)
     }
 
-    private func formContent(viewStore: ViewStore<BugReportReducer.State, BugReportReducer.Action>) -> some View {
+    private var formContent: some View {
         VStack(alignment: .leading, spacing: 24) {
-            bugLocationField(viewStore: viewStore)
-            bugDescriptionTextView(viewStore: viewStore)
-            bugImageSection(viewStore: viewStore)
+            bugLocationField
+            bugDescriptionTextView
+            bugImageSection
         }
         .padding(.horizontal, 24)
         .padding(.top, 28)
     }
 
-    private func bugLocationField(viewStore: ViewStore<BugReportReducer.State, BugReportReducer.Action>) -> some View {
+    private var bugLocationField: some View {
         PiCKTextField(
-            text: viewStore.binding(
-                get: \.bugLocation,
-                send: { .bugLocationChanged($0) }
-            ),
+            text: $store.bugLocation,
             placeholder: "예: 메인, 외출 신청",
             titleText: "어디서 버그가 발생했나요?"
         )
     }
 
-    private func bugDescriptionTextView(viewStore: ViewStore<BugReportReducer.State, BugReportReducer.Action>) -> some View {
+    private var bugDescriptionTextView: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("버그에 대해 설명해주세요")
                 .pickText(type: .label1, textColor: .Normal.black)
 
             ZStack(alignment: .topLeading) {
-                TextEditor(text: viewStore.binding(
-                    get: \.bugDescription,
-                    send: { .bugDescriptionChanged($0) }
-                ))
+                TextEditor(text: $store.bugDescription)
                 .pickText(type: .caption2, textColor: .Normal.black)
                 .frame(height: 120)
                 .padding(.horizontal, 12)
@@ -109,7 +103,7 @@ public struct BugReportView: View {
                 .scrollContentBackground(.hidden)
                 .focused($isDescriptionFocused)
 
-                if viewStore.bugDescription.isEmpty {
+                if store.bugDescription.isEmpty {
                     Text("자세히 입력해주세요")
                         .pickText(type: .caption2, textColor: .Gray.gray500)
                         .padding(.horizontal, 16)
@@ -120,24 +114,24 @@ public struct BugReportView: View {
         }
     }
 
-    private func bugImageSection(viewStore: ViewStore<BugReportReducer.State, BugReportReducer.Action>) -> some View {
+    private var bugImageSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("버그 사진을 첨부해주세요")
                 .pickText(type: .label1, textColor: .Normal.black)
 
-            if viewStore.selectedImages.isEmpty {
+            if store.selectedImages.isEmpty {
                 photosPickerButton(hasImages: false)
                     .onChange(of: selectedItems) { newItems in
-                        handleImageSelection(newItems: newItems, viewStore: viewStore)
+                        handleImageSelection(newItems: newItems)
                     }
             } else {
                 HStack(spacing: 0) {
                     photosPickerButton(hasImages: true)
                         .onChange(of: selectedItems) { newItems in
-                            handleImageSelection(newItems: newItems, viewStore: viewStore)
+                            handleImageSelection(newItems: newItems)
                         }
 
-                    selectedImagesScrollView(viewStore: viewStore)
+                    selectedImagesScrollView
                         .padding(.leading, 24)
 
                     Spacer()
@@ -187,19 +181,19 @@ public struct BugReportView: View {
         }
     }
 
-    private func selectedImagesScrollView(viewStore: ViewStore<BugReportReducer.State, BugReportReducer.Action>) -> some View {
+    private var selectedImagesScrollView: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 12) {
-                ForEach(Array(viewStore.selectedImages.enumerated()), id: \.offset) { index, imageData in
+                ForEach(Array(store.selectedImages.enumerated()), id: \.offset) { index, imageData in
                     if let uiImage = UIImage(data: imageData) {
-                        imagePreview(uiImage: uiImage, index: index, viewStore: viewStore)
+                        imagePreview(uiImage: uiImage, index: index)
                     }
                 }
             }
         }
     }
 
-    private func imagePreview(uiImage: UIImage, index: Int, viewStore: ViewStore<BugReportReducer.State, BugReportReducer.Action>) -> some View {
+    private func imagePreview(uiImage: UIImage, index: Int) -> some View {
         ZStack(alignment: .topTrailing) {
             Image(uiImage: uiImage)
                 .resizable()
@@ -208,7 +202,7 @@ public struct BugReportView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 8))
 
             Button(action: {
-                viewStore.send(.removeImage(index))
+                store.send(.removeImage(index))
                 selectedItems.remove(at: index)
             }) {
                 Image(systemName: "xmark.circle.fill")
@@ -219,7 +213,7 @@ public struct BugReportView: View {
         }
     }
 
-    private func handleImageSelection(newItems: [PhotosPickerItem], viewStore: ViewStore<BugReportReducer.State, BugReportReducer.Action>) {
+    private func handleImageSelection(newItems: [PhotosPickerItem]) {
         Task {
             var images: [Data] = []
             for item in newItems {
@@ -229,16 +223,16 @@ public struct BugReportView: View {
                     images.append(compressedData)
                 }
             }
-            viewStore.send(.imagesSelected(images))
+            store.send(.imagesSelected(images))
         }
     }
 
-    private func submitButton(viewStore: ViewStore<BugReportReducer.State, BugReportReducer.Action>) -> some View {
+    private var submitButton: some View {
         PiCKButton(
-            buttonText: viewStore.isSubmitting ? "제보 중..." : "제보하기",
-            isEnabled: viewStore.isSubmitButtonEnabled && !viewStore.isSubmitting,
+            buttonText: store.isSubmitting ? "제보 중..." : "제보하기",
+            isEnabled: store.isSubmitButtonEnabled && !store.isSubmitting,
             action: {
-                viewStore.send(.submitButtonTapped)
+                store.send(.submitButtonTapped)
             }
         )
         .padding(.horizontal, 24)

--- a/Projects/Feature/BugReport/Tests/BugReportTests.swift
+++ b/Projects/Feature/BugReport/Tests/BugReportTests.swift
@@ -1,17 +1,138 @@
 import XCTest
+import Combine
+import ComposableArchitecture
+import BugReportDomainInterface
+import Utility
+@testable import BugReportFeature
 
+@MainActor
 final class BugReportTests: XCTestCase {
+    func testBugLocationBinding_UpdatesStateAndKeepsSubmitDisabledWithoutDescription() async {
+        let store = makeStore()
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the.
+        await store.send(
+            .binding(BindingAction<BugReportReducer.State>.allCasePaths.bugLocation.embed("메인"))
+        ) {
+            $0.bugLocation = "메인"
+            $0.isSubmitButtonEnabled = false
+        }
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func testBugDescriptionBinding_EnablesSubmitWhenLocationExists() async {
+        let store = makeStore(initialState: state(bugLocation: "메인"))
+
+        await store.send(
+            .binding(
+                BindingAction<BugReportReducer.State>.allCasePaths.bugDescription.embed("버튼이 눌리지 않아요")
+            )
+        ) {
+            $0.bugDescription = "버튼이 눌리지 않아요"
+            $0.isSubmitButtonEnabled = true
+        }
     }
 
-    func testExample() throws {
-        XCTAssertTrue(true)
+    func testImagesSelected_StoresImagesAndPreservesSubmitStateCalculation() async {
+        let imageData = Data([1, 2, 3])
+        let store = makeStore(initialState: state(bugLocation: "메인", bugDescription: "설명"))
+
+        await store.send(.imagesSelected([imageData])) {
+            $0.selectedImages = [imageData]
+            $0.isSubmitButtonEnabled = true
+        }
     }
 
+    func testSubmitSuccessWithoutImages_ShowsSuccessAndResetsForm() async {
+        let store = makeStore(
+            uploadUseCase: UploadBugImagesUseCaseSpy(),
+            submitUseCase: SubmitBugReportUseCaseSpy { _, _, _ in
+                Just(())
+                    .setFailureType(to: Error.self)
+                    .eraseToAnyPublisher()
+            },
+            initialState: state(bugLocation: "메인", bugDescription: "설명", isSubmitButtonEnabled: true)
+        )
+
+        await store.send(.submitButtonTapped) {
+            $0.isSubmitting = true
+        }
+        await store.receive(
+            {
+                if case .submitBugReportResponse(.success) = $0 {
+                    return true
+                }
+                return false
+            }
+        ) {
+            $0.isSubmitting = false
+            $0.alertSuccessType = .success
+            $0.alertMessage = "버그 제보가 완료되었습니다"
+            $0.showAlert = true
+            $0.shouldDismiss = true
+            $0.bugLocation = ""
+            $0.bugDescription = ""
+            $0.selectedImages = []
+            $0.isSubmitButtonEnabled = false
+        }
+    }
+
+    private func makeStore(
+        uploadUseCase: any UploadBugImagesUseCaseProtocol = UploadBugImagesUseCaseSpy(),
+        submitUseCase: any SubmitBugReportUseCaseProtocol = SubmitBugReportUseCaseSpy(),
+        initialState: BugReportReducer.State = .init()
+    ) -> TestStore<BugReportReducer.State, BugReportReducer.Action> {
+        TestStore(initialState: initialState) {
+            BugReportReducer(
+                uploadBugImagesUseCase: uploadUseCase,
+                submitBugReportUseCase: submitUseCase
+            )
+        }
+    }
+
+    private func state(
+        bugLocation: String = "",
+        bugDescription: String = "",
+        isSubmitButtonEnabled: Bool = false
+    ) -> BugReportReducer.State {
+        var state = BugReportReducer.State()
+        state.bugLocation = bugLocation
+        state.bugDescription = bugDescription
+        state.isSubmitButtonEnabled = isSubmitButtonEnabled
+        return state
+    }
+}
+
+private final class UploadBugImagesUseCaseSpy: UploadBugImagesUseCaseProtocol {
+    private let executeHandler: ([Data]) -> AnyPublisher<[String], Error>
+
+    init(
+        executeHandler: @escaping ([Data]) -> AnyPublisher<[String], Error> = { _ in
+            Empty(completeImmediately: true)
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+    ) {
+        self.executeHandler = executeHandler
+    }
+
+    func execute(images: [Data]) -> AnyPublisher<[String], Error> {
+        executeHandler(images)
+    }
+}
+
+private final class SubmitBugReportUseCaseSpy: SubmitBugReportUseCaseProtocol {
+    private let executeHandler: (String, String, [String]) -> AnyPublisher<Void, Error>
+
+    init(
+        executeHandler: @escaping (String, String, [String]) -> AnyPublisher<Void, Error> = { _, _, _ in
+            Empty(completeImmediately: true)
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+    ) {
+        self.executeHandler = executeHandler
+    }
+
+    func execute(title: String, content: String, fileNames: [String]) -> AnyPublisher<Void, Error> {
+        executeHandler(title, content, fileNames)
+    }
 }

--- a/Projects/Feature/ChangePassword/Project.swift
+++ b/Projects/Feature/ChangePassword/Project.swift
@@ -39,8 +39,27 @@ let implementationTarget = Target.target(
     sources: ["Sources/**"],
     dependencies: [
         .target(name: "ChangePasswordFeatureInterface"),
+        .Projects.authDomainInterface,
+        .Projects.changePasswordDomainInterface,
+        .Shared.utility,
+        .SPM.PDS,
         .SPM.NeedleFoundation,
         .SPM.ComposableArchitecture
+    ]
+)
+
+let testTarget = Target.target(
+    name: "ChangePasswordFeatureTests",
+    destinations: env.destination,
+    product: .unitTests,
+    bundleId: "\(env.organizationName).ChangePasswordFeatureTests",
+    deploymentTargets: env.deploymentTargets,
+    infoPlist: .default,
+    sources: ["Tests/**"],
+    dependencies: [
+        .target(name: "ChangePasswordFeature"),
+        .target(name: "ChangePasswordFeatureInterface"),
+        .Projects.authDomainInterface
     ]
 )
 
@@ -48,5 +67,5 @@ let project = Project(
     name: "ChangePasswordFeature",
     organizationName: env.organizationName,
     settings: settings,
-    targets: [interfaceTarget, implementationTarget]
+    targets: [interfaceTarget, implementationTarget, testTarget]
 )

--- a/Projects/Feature/ChangePassword/Sources/Scene/ChangePassword/ChangePasswordReducer.swift
+++ b/Projects/Feature/ChangePassword/Sources/Scene/ChangePassword/ChangePasswordReducer.swift
@@ -25,9 +25,8 @@ public struct ChangePasswordReducer: Reducer {
         public init() {}
     }
 
-    public enum Action {
-        case emailChanged(String)
-        case codeChanged(String)
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
         case verificationButtonTapped
         case nextButtonTapped
         case emailSendResponse(TaskResult<Void>)
@@ -36,15 +35,11 @@ public struct ChangePasswordReducer: Reducer {
     }
 
     public var body: some ReducerOf<Self> {
+        BindingReducer()
+
         Reduce { state, action in
             switch action {
-            case let .emailChanged(email):
-                state.email = email
-                state.errorMessage = nil
-                return .none
-
-            case let .codeChanged(code):
-                state.code = code
+            case .binding:
                 state.errorMessage = nil
                 return .none
 

--- a/Projects/Feature/ChangePassword/Sources/Scene/ChangePassword/ChangePasswordReducer.swift
+++ b/Projects/Feature/ChangePassword/Sources/Scene/ChangePassword/ChangePasswordReducer.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import AuthDomainInterface
 
+@Reducer
 public struct ChangePasswordReducer: Reducer {
     private let emailSendUseCase: any EmailSendUseCase
     private let codeCheckUseCase: any CodeCheckUseCase
@@ -13,6 +14,7 @@ public struct ChangePasswordReducer: Reducer {
         self.codeCheckUseCase = codeCheckUseCase
     }
 
+    @ObservableState
     public struct State: Equatable {
         public var email = ""
         public var code = ""
@@ -33,7 +35,7 @@ public struct ChangePasswordReducer: Reducer {
         case clearSuccessMessage
     }
 
-    public var body: some Reducer<State, Action> {
+    public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case let .emailChanged(email):

--- a/Projects/Feature/ChangePassword/Sources/Scene/ChangePassword/ChangePasswordView.swift
+++ b/Projects/Feature/ChangePassword/Sources/Scene/ChangePassword/ChangePasswordView.swift
@@ -13,13 +13,13 @@ public struct ChangePasswordView: View {
     }
 
     public var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
+        WithPerceptionTracking {
             VStack(alignment: .leading, spacing: 0) {
                 headerSection
-                emailTextField(viewStore)
-                codeTextField(viewStore)
+                emailTextField
+                codeTextField
 
-                if let errorMessage = viewStore.errorMessage {
+                if let errorMessage = store.errorMessage {
                     Text(errorMessage)
                         .pickText(type: .body1, textColor: .Error.error)
                         .padding(.horizontal, 24)
@@ -27,12 +27,12 @@ public struct ChangePasswordView: View {
                 }
 
                 Spacer()
-                nextButton(viewStore)
+                nextButton
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .onChange(of: viewStore.accountId) { accountId in
-                if let accountId = accountId, !viewStore.code.isEmpty {
-                    router.path.append(.newPassword(accountId: accountId, code: viewStore.code))
+            .onChange(of: store.accountId) { accountId in
+                if let accountId = accountId, !store.code.isEmpty {
+                    router.path.append(.newPassword(accountId: accountId, code: store.code))
                 }
             }
             .navigationBarBackButtonHidden(true)
@@ -50,7 +50,7 @@ public struct ChangePasswordView: View {
                 }
             }
             .overlay(alignment: .top) {
-                if let successMessage = viewStore.successMessage {
+                if let successMessage = store.successMessage {
                     VStack {
                         HStack(spacing: 8) {
                             Image(systemName: "checkmark.circle.fill")
@@ -67,12 +67,12 @@ public struct ChangePasswordView: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
                     .onAppear {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                            viewStore.send(.clearSuccessMessage)
+                            store.send(.clearSuccessMessage)
                         }
                     }
                 }
             }
-            .animation(.spring(), value: viewStore.successMessage)
+            .animation(.spring(), value: store.successMessage)
         }
     }
 
@@ -92,28 +92,28 @@ public struct ChangePasswordView: View {
         .padding(.leading, 24)
     }
 
-    private func emailTextField(_ viewStore: ViewStoreOf<ChangePasswordReducer>) -> some View {
+    private var emailTextField: some View {
         PiCKTextField(
-            text: viewStore.binding(
-                get: \.email,
-                send: ChangePasswordReducer.Action.emailChanged
+            text: Binding(
+                get: { store.email },
+                set: { store.send(.emailChanged($0)) }
             ),
             placeholder: "학교 이메일을 입력해주세요",
             titleText: "이메일",
             showVerification: true,
             verificationButtonTapped: {
-                viewStore.send(.verificationButtonTapped)
+                store.send(.verificationButtonTapped)
             }
         )
         .padding(.horizontal, 24)
         .padding(.top, 50)
     }
 
-    private func codeTextField(_ viewStore: ViewStoreOf<ChangePasswordReducer>) -> some View {
+    private var codeTextField: some View {
         PiCKTextField(
-            text: viewStore.binding(
-                get: \.code,
-                send: ChangePasswordReducer.Action.codeChanged
+            text: Binding(
+                get: { store.code },
+                set: { store.send(.codeChanged($0)) }
             ),
             placeholder: "인증 코드를 입력해주세요",
             titleText: "인증 코드"
@@ -122,11 +122,11 @@ public struct ChangePasswordView: View {
         .padding(.top, 44)
     }
 
-    private func nextButton(_ viewStore: ViewStoreOf<ChangePasswordReducer>) -> some View {
+    private var nextButton: some View {
         PiCKButton(
             buttonText: "다음",
-            isEnabled: !viewStore.email.isEmpty && !viewStore.code.isEmpty,
-            action: { viewStore.send(.nextButtonTapped) }
+            isEnabled: !store.email.isEmpty && !store.code.isEmpty,
+            action: { store.send(.nextButtonTapped) }
         )
         .padding(.horizontal, 24)
         .padding(.bottom, 28)

--- a/Projects/Feature/ChangePassword/Sources/Scene/ChangePassword/ChangePasswordView.swift
+++ b/Projects/Feature/ChangePassword/Sources/Scene/ChangePassword/ChangePasswordView.swift
@@ -4,7 +4,7 @@ import PiCK_iOS_DesignSystem
 import Utility
 
 public struct ChangePasswordView: View {
-    let store: StoreOf<ChangePasswordReducer>
+    @Perception.Bindable var store: StoreOf<ChangePasswordReducer>
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var router: AppRouter
 
@@ -94,10 +94,7 @@ public struct ChangePasswordView: View {
 
     private var emailTextField: some View {
         PiCKTextField(
-            text: Binding(
-                get: { store.email },
-                set: { store.send(.emailChanged($0)) }
-            ),
+            text: $store.email,
             placeholder: "학교 이메일을 입력해주세요",
             titleText: "이메일",
             showVerification: true,
@@ -111,10 +108,7 @@ public struct ChangePasswordView: View {
 
     private var codeTextField: some View {
         PiCKTextField(
-            text: Binding(
-                get: { store.code },
-                set: { store.send(.codeChanged($0)) }
-            ),
+            text: $store.code,
             placeholder: "인증 코드를 입력해주세요",
             titleText: "인증 코드"
         )

--- a/Projects/Feature/ChangePassword/Tests/ChangePasswordTests.swift
+++ b/Projects/Feature/ChangePassword/Tests/ChangePasswordTests.swift
@@ -6,6 +6,24 @@ import AuthDomainInterface
 
 @MainActor
 final class ChangePasswordTests: XCTestCase {
+    func testEmailBinding_UpdatesEmailAndClearsError() async {
+        let store = makeStore(initialState: state(errorMessage: "old error"))
+
+        await store.send(\.binding.email, "pick@dsm.hs.kr") {
+            $0.email = "pick@dsm.hs.kr"
+            $0.errorMessage = nil
+        }
+    }
+
+    func testCodeBinding_UpdatesCodeAndClearsError() async {
+        let store = makeStore(initialState: state(errorMessage: "old error"))
+
+        await store.send(\.binding.code, "123456") {
+            $0.code = "123456"
+            $0.errorMessage = nil
+        }
+    }
+
     func testVerificationButtonTapped_WithEmptyEmail_SetsValidationError() async {
         let emailSendUseCase = EmailSendUseCaseSpy()
         let codeCheckUseCase = CodeCheckUseCaseSpy()
@@ -204,6 +222,16 @@ final class ChangePasswordTests: XCTestCase {
     }
 
     private func makeStore(
+        initialState: ChangePasswordReducer.State = .init()
+    ) -> TestStore<ChangePasswordReducer.State, ChangePasswordReducer.Action> {
+        makeStore(
+            emailSendUseCase: EmailSendUseCaseSpy(),
+            codeCheckUseCase: CodeCheckUseCaseSpy(),
+            initialState: initialState
+        )
+    }
+
+    private func makeStore(
         emailSendUseCase: any EmailSendUseCase,
         codeCheckUseCase: any CodeCheckUseCase,
         initialState: ChangePasswordReducer.State = .init()
@@ -214,6 +242,18 @@ final class ChangePasswordTests: XCTestCase {
                 codeCheckUseCase: codeCheckUseCase
             )
         }
+    }
+
+    private func state(
+        email: String = "",
+        code: String = "",
+        errorMessage: String? = nil
+    ) -> ChangePasswordReducer.State {
+        var state = ChangePasswordReducer.State()
+        state.email = email
+        state.code = code
+        state.errorMessage = errorMessage
+        return state
     }
 }
 

--- a/Projects/Feature/ChangePassword/Tests/ChangePasswordTests.swift
+++ b/Projects/Feature/ChangePassword/Tests/ChangePasswordTests.swift
@@ -1,17 +1,270 @@
 import XCTest
+import Combine
+import ComposableArchitecture
+import AuthDomainInterface
+@testable import ChangePasswordFeature
 
+@MainActor
 final class ChangePasswordTests: XCTestCase {
+    func testVerificationButtonTapped_WithEmptyEmail_SetsValidationError() async {
+        let emailSendUseCase = EmailSendUseCaseSpy()
+        let codeCheckUseCase = CodeCheckUseCaseSpy()
+        let store = makeStore(
+            emailSendUseCase: emailSendUseCase,
+            codeCheckUseCase: codeCheckUseCase
+        )
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the.
+        await store.send(ChangePasswordReducer.Action.verificationButtonTapped) {
+            $0.errorMessage = "이메일을 입력해주세요"
+        }
+
+        XCTAssertFalse(store.state.isVerificationSent)
+        XCTAssertTrue(emailSendUseCase.receivedRequests.isEmpty)
+        XCTAssertTrue(codeCheckUseCase.receivedRequests.isEmpty)
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func testNextButtonTapped_WithEmptyField_SetsValidationError() async {
+        let emailSendUseCase = EmailSendUseCaseSpy()
+        let codeCheckUseCase = CodeCheckUseCaseSpy()
+        var initialState = ChangePasswordReducer.State()
+        initialState.email = "pick@dsm.hs.kr"
+        let store = makeStore(
+            emailSendUseCase: emailSendUseCase,
+            codeCheckUseCase: codeCheckUseCase,
+            initialState: initialState
+        )
+
+        await store.send(ChangePasswordReducer.Action.nextButtonTapped) {
+            $0.errorMessage = "모든 필드를 입력해주세요"
+        }
+
+        XCTAssertNil(store.state.accountId)
+        XCTAssertTrue(codeCheckUseCase.receivedRequests.isEmpty)
     }
 
-    func testExample() throws {
-        XCTAssertTrue(true)
+    func testVerificationButtonTapped_OnSuccess_SetsVerificationSuccessState() async {
+        let emailSendUseCase = EmailSendUseCaseSpy { _ in
+            Just(())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+        let codeCheckUseCase = CodeCheckUseCaseSpy()
+        var initialState = ChangePasswordReducer.State()
+        initialState.email = "pick@dsm.hs.kr"
+        initialState.errorMessage = "old error"
+        let store = makeStore(
+            emailSendUseCase: emailSendUseCase,
+            codeCheckUseCase: codeCheckUseCase,
+            initialState: initialState
+        )
+
+        await store.send(ChangePasswordReducer.Action.verificationButtonTapped)
+        await store.receive(
+            {
+                if case .emailSendResponse(.success) = $0 {
+                    return true
+                }
+                return false
+            }
+        ) {
+            $0.isVerificationSent = true
+            $0.errorMessage = nil
+            $0.successMessage = "이메일로 코드가 전송되었어요!"
+        }
+
+        XCTAssertEqual(emailSendUseCase.receivedRequests.count, 1)
+        XCTAssertEqual(emailSendUseCase.receivedRequests.first?.mail, "pick@dsm.hs.kr")
+        XCTAssertEqual(emailSendUseCase.receivedRequests.first?.title, "비밀번호 변경 인증")
+        XCTAssertEqual(emailSendUseCase.receivedRequests.first?.message, "비밀번호 변경 인증")
     }
 
+    func testVerificationButtonTapped_OnFailure_PropagatesErrorMessage() async {
+        let emailSendUseCase = EmailSendUseCaseSpy { _ in
+            Fail(error: TestError("send failed"))
+                .eraseToAnyPublisher()
+        }
+        let codeCheckUseCase = CodeCheckUseCaseSpy()
+        var initialState = ChangePasswordReducer.State()
+        initialState.email = "pick@dsm.hs.kr"
+        let store = makeStore(
+            emailSendUseCase: emailSendUseCase,
+            codeCheckUseCase: codeCheckUseCase,
+            initialState: initialState
+        )
+
+        await store.send(ChangePasswordReducer.Action.verificationButtonTapped)
+        await store.receive(
+            {
+                if case let .emailSendResponse(.failure(error)) = $0 {
+                    return error.localizedDescription == "send failed"
+                }
+                return false
+            }
+        ) {
+            $0.errorMessage = "send failed"
+            $0.successMessage = nil
+        }
+
+        XCTAssertFalse(store.state.isVerificationSent)
+    }
+
+    func testNextButtonTapped_WithInvalidCode_SetsExpectedError() async {
+        let emailSendUseCase = EmailSendUseCaseSpy()
+        let codeCheckUseCase = CodeCheckUseCaseSpy { _ in
+            Just(false)
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+        var initialState = ChangePasswordReducer.State()
+        initialState.email = "pick@dsm.hs.kr"
+        initialState.code = "123456"
+        let store = makeStore(
+            emailSendUseCase: emailSendUseCase,
+            codeCheckUseCase: codeCheckUseCase,
+            initialState: initialState
+        )
+
+        await store.send(ChangePasswordReducer.Action.nextButtonTapped)
+        await store.receive(
+            {
+                if case .codeCheckResponse(.success(false)) = $0 {
+                    return true
+                }
+                return false
+            }
+        ) {
+            $0.errorMessage = "인증코드가 올바르지 않습니다"
+        }
+
+        XCTAssertEqual(codeCheckUseCase.receivedRequests.count, 1)
+        XCTAssertEqual(codeCheckUseCase.receivedRequests.first?.email, "pick@dsm.hs.kr")
+        XCTAssertEqual(codeCheckUseCase.receivedRequests.first?.code, "123456")
+        XCTAssertNil(store.state.accountId)
+    }
+
+    func testNextButtonTapped_OnSuccessfulCodeCheck_SetsAccountId() async {
+        let emailSendUseCase = EmailSendUseCaseSpy()
+        let codeCheckUseCase = CodeCheckUseCaseSpy { _ in
+            Just(true)
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+        var initialState = ChangePasswordReducer.State()
+        initialState.email = "pick@dsm.hs.kr"
+        initialState.code = "123456"
+        initialState.errorMessage = "old error"
+        let store = makeStore(
+            emailSendUseCase: emailSendUseCase,
+            codeCheckUseCase: codeCheckUseCase,
+            initialState: initialState
+        )
+
+        await store.send(ChangePasswordReducer.Action.nextButtonTapped)
+        await store.receive(
+            {
+                if case .codeCheckResponse(.success(true)) = $0 {
+                    return true
+                }
+                return false
+            }
+        ) {
+            $0.accountId = "pick@dsm.hs.kr"
+            $0.errorMessage = nil
+        }
+    }
+
+    func testNextButtonTapped_OnCodeCheckFailure_PropagatesErrorMessage() async {
+        let emailSendUseCase = EmailSendUseCaseSpy()
+        let codeCheckUseCase = CodeCheckUseCaseSpy { _ in
+            Fail(error: TestError("check failed"))
+                .eraseToAnyPublisher()
+        }
+        var initialState = ChangePasswordReducer.State()
+        initialState.email = "pick@dsm.hs.kr"
+        initialState.code = "123456"
+        let store = makeStore(
+            emailSendUseCase: emailSendUseCase,
+            codeCheckUseCase: codeCheckUseCase,
+            initialState: initialState
+        )
+
+        await store.send(ChangePasswordReducer.Action.nextButtonTapped)
+        await store.receive(
+            {
+                if case let .codeCheckResponse(.failure(error)) = $0 {
+                    return error.localizedDescription == "check failed"
+                }
+                return false
+            }
+        ) {
+            $0.errorMessage = "check failed"
+        }
+
+        XCTAssertNil(store.state.accountId)
+    }
+
+    private func makeStore(
+        emailSendUseCase: any EmailSendUseCase,
+        codeCheckUseCase: any CodeCheckUseCase,
+        initialState: ChangePasswordReducer.State = .init()
+    ) -> TestStore<ChangePasswordReducer.State, ChangePasswordReducer.Action> {
+        TestStore(initialState: initialState) {
+            ChangePasswordReducer(
+                emailSendUseCase: emailSendUseCase,
+                codeCheckUseCase: codeCheckUseCase
+            )
+        }
+    }
+}
+
+private final class EmailSendUseCaseSpy: EmailSendUseCase {
+    private let executeHandler: (EmailSendRequestParams) -> AnyPublisher<Void, Error>
+    private(set) var receivedRequests: [EmailSendRequestParams] = []
+
+    init(
+        executeHandler: @escaping (EmailSendRequestParams) -> AnyPublisher<Void, Error> = { _ in
+            Empty(completeImmediately: true)
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+    ) {
+        self.executeHandler = executeHandler
+    }
+
+    func execute(req: EmailSendRequestParams) -> AnyPublisher<Void, Error> {
+        receivedRequests.append(req)
+        return executeHandler(req)
+    }
+}
+
+private final class CodeCheckUseCaseSpy: CodeCheckUseCase {
+    private let executeHandler: (CodeCheckRequestParams) -> AnyPublisher<Bool, Error>
+    private(set) var receivedRequests: [CodeCheckRequestParams] = []
+
+    init(
+        executeHandler: @escaping (CodeCheckRequestParams) -> AnyPublisher<Bool, Error> = { _ in
+            Empty(completeImmediately: true)
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+    ) {
+        self.executeHandler = executeHandler
+    }
+
+    func execute(req: CodeCheckRequestParams) -> AnyPublisher<Bool, Error> {
+        receivedRequests.append(req)
+        return executeHandler(req)
+    }
+}
+
+private struct TestError: LocalizedError {
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    var errorDescription: String? {
+        message
+    }
 }

--- a/Projects/Feature/OutingHistoryFeature/Project.swift
+++ b/Projects/Feature/OutingHistoryFeature/Project.swift
@@ -39,8 +39,25 @@ let implementationTarget = Target.target(
     sources: ["Sources/**"],
     dependencies: [
         .target(name: "OutingHistoryFeatureInterface"),
+        .Projects.outingHistoryDomainInterface,
+        .SPM.PDS,
         .SPM.NeedleFoundation,
         .SPM.ComposableArchitecture
+    ]
+)
+
+let testTarget = Target.target(
+    name: "OutingHistoryFeatureTests",
+    destinations: env.destination,
+    product: .unitTests,
+    bundleId: "\(env.organizationName).OutingHistoryFeatureTests",
+    deploymentTargets: env.deploymentTargets,
+    infoPlist: .default,
+    sources: ["Tests/**"],
+    dependencies: [
+        .target(name: "OutingHistoryFeature"),
+        .target(name: "OutingHistoryFeatureInterface"),
+        .Projects.outingHistoryDomainInterface
     ]
 )
 
@@ -48,5 +65,5 @@ let project = Project(
     name: "OutingHistoryFeature",
     organizationName: env.organizationName,
     settings: settings,
-    targets: [interfaceTarget, implementationTarget]
+    targets: [interfaceTarget, implementationTarget, testTarget]
 )

--- a/Projects/Feature/OutingHistoryFeature/Sources/OutingHistoryReducer.swift
+++ b/Projects/Feature/OutingHistoryFeature/Sources/OutingHistoryReducer.swift
@@ -4,6 +4,7 @@ import Foundation
 import Combine
 import OutingHistoryDomainInterface
 
+@Reducer
 public struct OutingHistoryReducer: Reducer {
     private let getOutingHistoryUseCase: any GetOutingHistoryUseCase
 
@@ -13,6 +14,7 @@ public struct OutingHistoryReducer: Reducer {
         self.getOutingHistoryUseCase = getOutingHistoryUseCase
     }
 
+    @ObservableState
     public struct State: Equatable {
         public var studentItems: [OutingHistoryEntity] = []
         public var searchText: String = ""
@@ -21,15 +23,19 @@ public struct OutingHistoryReducer: Reducer {
         public init() {}
     }
 
-    public enum Action {
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
         case onAppear
         case outingHistoryResponse(TaskResult<[OutingHistoryEntity]>)
-        case searchTextChanged(String)
     }
 
-    public var body: some Reducer<State, Action> {
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+
         Reduce { state, action in
             switch action {
+            case .binding:
+                return .none
             case .onAppear:
                 state.isLoading = true
                 return loadOutingHistory()
@@ -40,9 +46,6 @@ public struct OutingHistoryReducer: Reducer {
             case .outingHistoryResponse(.failure(_)):
                 // 에러 처리 필요
                 state.isLoading = false
-                return .none
-            case let .searchTextChanged(searchText):
-                state.searchText = searchText
                 return .none
             }
         }

--- a/Projects/Feature/OutingHistoryFeature/Sources/Scene/OutingHistoryView.swift
+++ b/Projects/Feature/OutingHistoryFeature/Sources/Scene/OutingHistoryView.swift
@@ -5,14 +5,14 @@ import PiCK_iOS_DesignSystem
 
 public struct OutingHistoryView: View {
     @Environment(\.dismiss) var dismiss
-    let store: StoreOf<OutingHistoryReducer>
+    @Perception.Bindable var store: StoreOf<OutingHistoryReducer>
 
     public init(store: StoreOf<OutingHistoryReducer>) {
         self.store = store
     }
 
     public var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
+        WithPerceptionTracking {
             ZStack {
                 VStack(spacing: 0) {
                     HStack(spacing: 4) {
@@ -22,10 +22,7 @@ public struct OutingHistoryView: View {
 
                         TextField(
                             "이름 또는 학번으로 검색",
-                            text: viewStore.binding(
-                                get: \.searchText,
-                                send: OutingHistoryReducer.Action.searchTextChanged
-                            )
+                            text: $store.searchText
                         )
                         .textFieldStyle(PlainTextFieldStyle())
                         .padding(.horizontal, 16)
@@ -38,13 +35,13 @@ public struct OutingHistoryView: View {
                     .padding(.horizontal, 24)
 
                     Group {
-                        if viewStore.isLoading {
+                        if store.isLoading {
                             VStack {
                                 Spacer()
                                 ProgressView()
                                 Spacer()
                             }
-                        } else if viewStore.filteredStudentItems.isEmpty {
+                        } else if store.filteredStudentItems.isEmpty {
                             VStack {
                                 Spacer()
                                 VStack(spacing: 12) {
@@ -60,7 +57,7 @@ public struct OutingHistoryView: View {
                         } else {
                             ScrollView {
                                 VStack {
-                                    ForEach(viewStore.filteredStudentItems, id: \.id) { data in
+                                    ForEach(store.filteredStudentItems, id: \.id) { data in
                                         OutingHistoryCell(data: data)
                                     }
                                 }
@@ -68,7 +65,7 @@ public struct OutingHistoryView: View {
                         }
                     }
                 }.onAppear {
-                    viewStore.send(.onAppear)
+                    store.send(.onAppear)
                 }
                 .navigationTitle("이전 외출 기록")
                 .navigationBarTitleDisplayMode(.inline)

--- a/Projects/Feature/OutingHistoryFeature/Tests/OutingHistoryTests.swift
+++ b/Projects/Feature/OutingHistoryFeature/Tests/OutingHistoryTests.swift
@@ -1,17 +1,119 @@
 import XCTest
+import Combine
+import ComposableArchitecture
+import OutingHistoryDomainInterface
+@testable import OutingHistoryFeature
 
+@MainActor
 final class OutingHistoryTests: XCTestCase {
+    func testSearchBinding_UpdatesState() async {
+        let store = makeStore()
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the.
+        await store.send(
+            .binding(BindingAction<OutingHistoryReducer.State>.allCasePaths.searchText.embed("김철수"))
+        ) {
+            $0.searchText = "김철수"
+        }
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func testFilteredStudentItems_FiltersByNameAndStudentNumber() {
+        var state = OutingHistoryReducer.State()
+        state.studentItems = sampleItems
+        state.searchText = "1101김"
+
+        XCTAssertEqual(state.filteredStudentItems.map(\.id), ["1"])
     }
 
-    func testExample() throws {
-        XCTAssertTrue(true)
+    func testOnAppear_SetsLoadingThenStoresLoadedItems() async {
+        let store = makeStore(
+            useCase: GetOutingHistoryUseCaseSpy {
+                Just(self.sampleItems)
+                    .setFailureType(to: Error.self)
+                    .eraseToAnyPublisher()
+            }
+        )
+
+        await store.send(OutingHistoryReducer.Action.onAppear) {
+            $0.isLoading = true
+        }
+        await store.receive(
+            {
+                if case .outingHistoryResponse(.success(let students)) = $0 {
+                    return students == self.sampleItems
+                }
+                return false
+            }
+        ) {
+            $0.isLoading = false
+            $0.studentItems = self.sampleItems
+        }
     }
 
+    func testOnAppear_FailureClearsLoading() async {
+        let store = makeStore(
+            useCase: GetOutingHistoryUseCaseSpy {
+                Fail(error: TestError("load failed"))
+                    .eraseToAnyPublisher()
+            }
+        )
+
+        await store.send(OutingHistoryReducer.Action.onAppear) {
+            $0.isLoading = true
+        }
+        await store.receive(
+            {
+                if case let .outingHistoryResponse(.failure(error)) = $0 {
+                    return error.localizedDescription == "load failed"
+                }
+                return false
+            }
+        ) {
+            $0.isLoading = false
+        }
+    }
+
+    private func makeStore(
+        useCase: any GetOutingHistoryUseCase = GetOutingHistoryUseCaseSpy()
+    ) -> TestStore<OutingHistoryReducer.State, OutingHistoryReducer.Action> {
+        TestStore(initialState: OutingHistoryReducer.State()) {
+            OutingHistoryReducer(getOutingHistoryUseCase: useCase)
+        }
+    }
+
+    private var sampleItems: [OutingHistoryEntity] {
+        [
+            .init(id: "1", userName: "김철수", grade: 1, classNum: 1, num: 1, applicationCnt: 2, earlyReturnCnt: 0),
+            .init(id: "2", userName: "이영희", grade: 2, classNum: 3, num: 4, applicationCnt: 1, earlyReturnCnt: 1)
+        ]
+    }
+}
+
+private final class GetOutingHistoryUseCaseSpy: GetOutingHistoryUseCase {
+    private let executeHandler: () -> AnyPublisher<[OutingHistoryEntity], Error>
+
+    init(
+        executeHandler: @escaping () -> AnyPublisher<[OutingHistoryEntity], Error> = {
+            Empty(completeImmediately: true)
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+    ) {
+        self.executeHandler = executeHandler
+    }
+
+    func execute() -> AnyPublisher<[OutingHistoryEntity], Error> {
+        executeHandler()
+    }
+}
+
+private struct TestError: LocalizedError {
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    var errorDescription: String? {
+        message
+    }
 }

--- a/Projects/Feature/SignupFeature/Project.swift
+++ b/Projects/Feature/SignupFeature/Project.swift
@@ -40,7 +40,23 @@ let implementationTarget = Target.target(
     dependencies: [
         .target(name: "SignupFeatureInterface"),
         .Projects.authDomainInterface,
+        .SPM.ComposableArchitecture,
         .Shared.thirdPartyLib
+    ]
+)
+
+let testTarget = Target.target(
+    name: "SignupFeatureTests",
+    destinations: env.destination,
+    product: .unitTests,
+    bundleId: "\(env.organizationName).SignupFeatureTests",
+    deploymentTargets: env.deploymentTargets,
+    infoPlist: .default,
+    sources: ["Tests/**"],
+    dependencies: [
+        .target(name: "SignupFeature"),
+        .target(name: "SignupFeatureInterface"),
+        .Projects.authDomainInterface
     ]
 )
 
@@ -48,5 +64,5 @@ let project = Project(
     name: "SignupFeature",
     organizationName: env.organizationName,
     settings: settings,
-    targets: [interfaceTarget, implementationTarget]
+    targets: [interfaceTarget, implementationTarget, testTarget]
 )

--- a/Projects/Feature/SignupFeature/Sources/Password/PasswordReducer.swift
+++ b/Projects/Feature/SignupFeature/Sources/Password/PasswordReducer.swift
@@ -2,7 +2,9 @@ import ComposableArchitecture
 import Foundation
 import AuthDomainInterface
 
+@Reducer
 public struct PasswordReducer: Reducer {
+    @ObservableState
     public struct State: Equatable {
         public var secretKey = ""
         public var accountId = ""
@@ -19,21 +21,18 @@ public struct PasswordReducer: Reducer {
         }
     }
     
-    public enum Action {
-        case passwordChanged(String)
-        case passwordConfirmChanged(String)
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
         case nextButtonTapped
         case clearError
     }
     
-    public var body: some Reducer<State, Action> {
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+
         Reduce { state, action in
             switch action {
-            case let .passwordChanged(password):
-                state.password = password
-                return .none
-            case let .passwordConfirmChanged(password):
-                state.passwordConfirm = password
+            case .binding:
                 return .none
             case .nextButtonTapped:
                 let passwordRegex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&()])[A-Za-z\\d!@#$%^&()]{8,30}$"

--- a/Projects/Feature/SignupFeature/Sources/Password/Scene/PasswordView.swift
+++ b/Projects/Feature/SignupFeature/Sources/Password/Scene/PasswordView.swift
@@ -5,7 +5,7 @@ import Utility
 import BaseFeature
 
 struct PasswordView: View {
-    let store: StoreOf<PasswordReducer>
+    @Perception.Bindable var store: StoreOf<PasswordReducer>
     @EnvironmentObject var router: AppRouter
     @Environment(\.dismiss) var dismiss
 
@@ -14,7 +14,7 @@ struct PasswordView: View {
     }
 
     var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
+        WithPerceptionTracking {
             BaseView {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: 0) {
@@ -32,10 +32,7 @@ struct PasswordView: View {
                         .padding(.top, 12)
 
                     PiCKTextField(
-                        text: viewStore.binding(
-                            get: \.password,
-                            send: PasswordReducer.Action.passwordChanged
-                        ),
+                        text: $store.password,
                         placeholder: "8~30자 영문자, 숫자, 특수문자 포함하세요",
                         titleText: "비밀번호",
                         isSecurity: true
@@ -44,10 +41,7 @@ struct PasswordView: View {
                     .padding(.top, 50)
 
                     PiCKTextField(
-                        text: viewStore.binding(
-                            get: \.passwordConfirm,
-                            send: PasswordReducer.Action.passwordConfirmChanged
-                        ),
+                        text: $store.passwordConfirm,
                         placeholder: "위에 입력한 비밀번호를 다시 입력해주세요",
                         titleText: "비밀번호 확인",
                         isSecurity: true
@@ -59,29 +53,33 @@ struct PasswordView: View {
 
                     PiCKButton(
                         buttonText: "다음",
-                        isEnabled: !viewStore.password.isEmpty && !viewStore.passwordConfirm.isEmpty,
-                        action: { viewStore.send(.nextButtonTapped) }
+                        isEnabled: !store.password.isEmpty && !store.passwordConfirm.isEmpty,
+                        action: { store.send(.nextButtonTapped) }
                     )
                     .padding(.horizontal, 24)
                     .padding(.bottom, 28)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .onChange(of: viewStore.isSuccessful) { isSuccessful in
+            .onChange(of: store.isSuccessful) { isSuccessful in
                 if isSuccessful {
                     router.path.append(.infoSetting(
-                        secretKey: viewStore.secretKey,
-                        accountId: viewStore.accountId,
-                        code: viewStore.code,
-                        password: viewStore.password
+                        secretKey: store.secretKey,
+                        accountId: store.accountId,
+                        code: store.code,
+                        password: store.password
                     ))
                 }
             }
             .errorToast(
-                message: viewStore.errorMessage ?? "에러발생!",
-                isPresented: viewStore.binding(
-                    get: { $0.errorMessage != nil },
-                    send: .clearError
+                message: store.errorMessage ?? "에러발생!",
+                isPresented: Binding(
+                    get: { store.errorMessage != nil },
+                    set: { isPresented in
+                        if !isPresented {
+                            store.send(.clearError)
+                        }
+                    }
                 )
             )
             .navigationBarBackButtonHidden(true)

--- a/Projects/Feature/SignupFeature/Tests/SignupFeatureTests.swift
+++ b/Projects/Feature/SignupFeature/Tests/SignupFeatureTests.swift
@@ -1,15 +1,70 @@
 import XCTest
+import ComposableArchitecture
+@testable import SignupFeature
 
+@MainActor
 final class SignupFeatureTests: XCTestCase {
+    func testPasswordBinding_UpdatesState() async {
+        let store = makeStore()
 
-    override func setUpWithError() throws {
+        await store.send(
+            .binding(BindingAction<PasswordReducer.State>.allCasePaths.password.embed("Abcd1234!"))
+        ) {
+            $0.password = "Abcd1234!"
+        }
     }
 
-    override func tearDownWithError() throws {
+    func testPasswordConfirmBinding_UpdatesState() async {
+        let store = makeStore()
+
+        await store.send(
+            .binding(
+                BindingAction<PasswordReducer.State>.allCasePaths.passwordConfirm.embed("Abcd1234!")
+            )
+        ) {
+            $0.passwordConfirm = "Abcd1234!"
+        }
     }
 
-    func testExample() throws {
-        XCTAssertEqual(1, 1)
+    func testNextButtonTapped_WhenPasswordsDoNotMatch_ShowsError() async {
+        let store = makeStore(initialState: state(password: "Abcd1234!", passwordConfirm: "Abcd1234?"))
+
+        await store.send(.nextButtonTapped) {
+            $0.errorMessage = "비밀번호 일치하지 않습니다"
+        }
     }
 
+    func testNextButtonTapped_WhenPasswordFormatInvalid_ShowsError() async {
+        let store = makeStore(initialState: state(password: "short", passwordConfirm: "short"))
+
+        await store.send(.nextButtonTapped) {
+            $0.errorMessage = "8~30자 영문자, 숫자, 특수문자 포함하세요"
+        }
+    }
+
+    func testNextButtonTapped_WhenPasswordValid_MarksSuccess() async {
+        let store = makeStore(initialState: state(password: "Abcd1234!", passwordConfirm: "Abcd1234!"))
+
+        await store.send(.nextButtonTapped) {
+            $0.isSuccessful = true
+        }
+    }
+
+    private func makeStore(
+        initialState: PasswordReducer.State = .init()
+    ) -> TestStore<PasswordReducer.State, PasswordReducer.Action> {
+        TestStore(initialState: initialState) {
+            PasswordReducer()
+        }
+    }
+
+    private func state(
+        password: String = "",
+        passwordConfirm: String = ""
+    ) -> PasswordReducer.State {
+        var state = PasswordReducer.State()
+        state.password = password
+        state.passwordConfirm = passwordConfirm
+        return state
+    }
 }

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a792d0109389fdf28f5b27ad4507d398dfd9ee3ee028aadd6ed16d8bf2370015",
+  "originHash" : "1f5a6e6baafa89c633ba85255d8b6e7a05a3035b8fc4d5d0c75ba24768992eb9",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "5b0890fabfd68a2d375d68502bc3f54a8548c494",
-        "version" : "1.23.1"
+        "revision" : "1eaa6fa2ee57ac42843283b9fd3457af408c858d",
+        "version" : "1.25.5"
       }
     },
     {
@@ -357,8 +357,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "65806ffbc9eb3be026b56fafaf26de0bb8b132de",
-        "version" : "2.5.0"
+        "revision" : "32f35241b8be0719c4c7f00eb27713b1cadb6248",
+        "version" : "2.8.0"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.6"),
         .package(url: "https://github.com/ReactorKit/ReactorKit.git", from: "3.0.0"),
         .package(url: "https://github.com/kean/Pulse.git", from: "4.2.0"),
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", from: "1.23.1"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", from: "1.25.5"),
         .package(url: "https://github.com/uber/needle.git", from: "0.24.0")
     ],
     targets: [


### PR DESCRIPTION
## 개요
- 프로젝트 전반 TCA 1.25 modernization / 2.0 prep rollout의 첫 wave를 반영합니다.
- true `ComposableArchitecture2` 전환이 아니라, 공개 TCA 1.25.x 기준에서 `@Reducer`, `@ObservableState`, `@Perception.Bindable`, `BindableAction`, `BindingReducer` 중심으로 구식 패턴을 줄이는 작업입니다.
- 관련 이슈: #135

## 작업사항
- `ChangePassword`를 첫 safe pilot으로 정리
  - test target 추가
  - reducer behavior tests 추가
  - `@Reducer`, `@ObservableState` 적용
  - `WithViewStore` 제거
  - `@Perception.Bindable`, `BindableAction`, `BindingReducer` 적용
- `OutingHistory`를 두 번째 pilot으로 적용
  - feature-local test target 추가
  - search binding / loading behavior 테스트 추가
  - observation + bindable state 패턴 적용
- `BugReport` low-risk wave 적용
  - feature-local test target 추가
  - 텍스트 입력을 bindable state로 전환
  - submit button state 계산을 reducer-local로 정리
  - submit success path reset 회귀 수정
- `SignupFeature`의 `Password` 단계 modernize
  - `SignupFeatureTests` target 추가
  - `PasswordReducer`를 bindable state 패턴으로 전환
  - `PasswordView`를 최신 observation 패턴으로 정리
- 로컬 automation scratch state(`.omx/`, `.omc/`) ignore 처리

## UI
- 기존 사용자-visible 동작을 바꾸는 PR이 아니라, observation/binding 스타일 현대화와 테스트 기반 보강이 주 목적입니다.
- 잔여 UI 계약 리스크
  - `ChangePassword`: accountId 기반 라우팅, success message auto-clear는 reducer test로 직접 고정하지 않음
  - `OutingHistory`: keyboard dismiss는 manual behavior로 남아 있음
  - `BugReport`: image upload failure / submit failure / alert dismiss 세부 흐름은 추가 테스트 여지 있음
  - `Signup Password`: 다음 step 라우팅은 view contract 영역으로 남아 있음

## 검증
- `xcodebuild test -workspace /Users/leejh/Desktop/PiCK_iOS_ADMIN/PiCK_iOS_ADMIN.xcworkspace -scheme ChangePasswordFeature -destination "platform=iOS Simulator,name=iPhone 17,OS=26.4" -derivedDataPath /tmp/ChangePasswordFeatureTestsWS`
  - `Executed 9 tests, with 0 failures`
- `xcodebuild test -workspace /Users/leejh/Desktop/PiCK_iOS_ADMIN/PiCK_iOS_ADMIN.xcworkspace -scheme OutingHistoryFeature -destination "platform=iOS Simulator,name=iPhone 17,OS=26.4" -derivedDataPath /tmp/OutingHistoryFeatureTestsWS`
  - `Executed 4 tests, with 0 failures`
- `xcodebuild test -workspace /Users/leejh/Desktop/PiCK_iOS_ADMIN/PiCK_iOS_ADMIN.xcworkspace -scheme BugReportFeature -destination "platform=iOS Simulator,name=iPhone 17,OS=26.4" -derivedDataPath /tmp/BugReportFeatureTestsWS`
  - `Executed 4 tests, with 0 failures`
- `xcodebuild build-for-testing -workspace /Users/leejh/Desktop/PiCK_iOS_ADMIN/PiCK_iOS_ADMIN.xcworkspace -scheme SignupFeature -destination "platform=iOS Simulator,name=iPhone 17,OS=26.4" -derivedDataPath /tmp/SignupFeatureBuildForTesting-6`
  - build artifact 생성 확인 (`SignupFeature.framework`, `SignupFeatureTests.xctest`)
- `git diff --check` 통과

## 비고
- `SchoolMeal`은 `HomeFeature` 교차 의존성 때문에 현재 rollout stop gate로 보류했습니다.
- `Project.swift` 구조 개선은 별도 이슈 #136에서 다룹니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 내부 상태 관리 시스템 최적화로 앱의 성능과 안정성 향상
  * 주요 기능별 테스트 범위 확대로 소프트웨어 품질 개선
  * 핵심 라이브러리를 최신 버전으로 업그레이드하여 보안성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->