### PR TITLE
🔗 :: (#412) 금요일 자습 출결 교시 추가

### DIFF
--- a/Projects/Feature/SelfStudyCheck/Sources/Scene/SelfStudyCheckView.swift
+++ b/Projects/Feature/SelfStudyCheck/Sources/Scene/SelfStudyCheckView.swift
@@ -56,24 +56,23 @@ public struct SelfStudyCheckView: View {
                         .padding(.top, 20)
                         .padding(.horizontal, 24)
 
-                    HStack(spacing: 8) {
-                        ForEach(SelfStudyCheckReducer.Period.allCases, id: \.self) { period in
-                            Button {
-                                store.send(.selectPeriod(period), animation: .spring())
-                            } label: {
-                                Text(period.title)
-                                    .pickText(
-                                        type: .body1,
-                                        textColor: store.selectedPeriod == period ? .Primary.primary500 : .Gray.gray600
-                                    )
-                                    .frame(maxWidth: .infinity)
-                                    .frame(height: 32)
-                                    .background(
-                                        store.selectedPeriod == period
-                                        ? Color.Primary.primary50
-                                        : Color.clear
-                                    )
-                                    .cornerRadius(8)
+                    VStack(spacing: 8) {
+                        if store.periods.count == 5 {
+                            HStack(spacing: 8) {
+                                ForEach(store.periods.prefix(2), id: \.self) { period in
+                                    periodButton(period)
+                                }
+                            }
+                            HStack(spacing: 8) {
+                                ForEach(store.periods.suffix(3), id: \.self) { period in
+                                    periodButton(period)
+                                }
+                            }
+                        } else {
+                            HStack(spacing: 8) {
+                                ForEach(store.periods, id: \.self) { period in
+                                    periodButton(period)
+                                }
                             }
                         }
                     }
@@ -179,6 +178,29 @@ public struct SelfStudyCheckView: View {
 }
 
 extension SelfStudyCheckView {
+    @ViewBuilder
+    private func periodButton(_ period: SelfStudyCheckReducer.Period) -> some View {
+        WithPerceptionTracking {
+            Button {
+                store.send(.selectPeriod(period), animation: .spring())
+            } label: {
+                Text(period.title)
+                    .pickText(
+                        type: .body1,
+                        textColor: store.selectedPeriod == period ? .Primary.primary500 : .Gray.gray600
+                    )
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 32)
+                    .background(
+                        store.selectedPeriod == period
+                        ? Color.Primary.primary50
+                        : Color.clear
+                    )
+                    .cornerRadius(8)
+            }
+        }
+    }
+
     private func statusColor(_ status: String) -> Color {
         switch status {
         case "출석":

--- a/Projects/Feature/SelfStudyCheck/Sources/Scene/SelfStudyCheckView.swift
+++ b/Projects/Feature/SelfStudyCheck/Sources/Scene/SelfStudyCheckView.swift
@@ -56,14 +56,34 @@ public struct SelfStudyCheckView: View {
                         .padding(.top, 20)
                         .padding(.horizontal, 24)
 
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 8) {
-                            ForEach(store.periods, id: \.self) { period in
-                                periodButton(period)
+                    ScrollViewReader { proxy in
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 0) {
+                                Color.clear.frame(width: 0).id("periodStart")
+                                HStack(spacing: 8) {
+                                    ForEach(store.periods, id: \.self) { period in
+                                        periodButton(period)
+                                            .id(period)
+                                    }
+                                }
+                                .padding(.horizontal, 24)
                             }
                         }
-                        .padding(.horizontal, 24)
+                        .onAppear {
+                            guard let last = store.periods.last else { return }
+                            Task { @MainActor in
+                                try? await Task.sleep(for: .seconds(0.4))
+                                withAnimation(.easeInOut(duration: 0.4)) {
+                                    proxy.scrollTo(last, anchor: .trailing)
+                                }
+                                try? await Task.sleep(for: .seconds(0.6))
+                                withAnimation(.easeInOut(duration: 0.4)) {
+                                    proxy.scrollTo("periodStart", anchor: .leading)
+                                }
+                            }
+                        }
                     }
+                    .fixedSize(horizontal: false, vertical: true)
                     .padding(.top, 16)
 
                 ScrollView {

--- a/Projects/Feature/SelfStudyCheck/Sources/Scene/SelfStudyCheckView.swift
+++ b/Projects/Feature/SelfStudyCheck/Sources/Scene/SelfStudyCheckView.swift
@@ -56,27 +56,14 @@ public struct SelfStudyCheckView: View {
                         .padding(.top, 20)
                         .padding(.horizontal, 24)
 
-                    VStack(spacing: 8) {
-                        if store.periods.count == 5 {
-                            HStack(spacing: 8) {
-                                ForEach(store.periods.prefix(2), id: \.self) { period in
-                                    periodButton(period)
-                                }
-                            }
-                            HStack(spacing: 8) {
-                                ForEach(store.periods.suffix(3), id: \.self) { period in
-                                    periodButton(period)
-                                }
-                            }
-                        } else {
-                            HStack(spacing: 8) {
-                                ForEach(store.periods, id: \.self) { period in
-                                    periodButton(period)
-                                }
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(store.periods, id: \.self) { period in
+                                periodButton(period)
                             }
                         }
+                        .padding(.horizontal, 24)
                     }
-                    .padding(.horizontal, 24)
                     .padding(.top, 16)
 
                 ScrollView {
@@ -189,8 +176,7 @@ extension SelfStudyCheckView {
                         type: .body1,
                         textColor: store.selectedPeriod == period ? .Primary.primary500 : .Gray.gray600
                     )
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 32)
+                    .frame(width: 114, height: 32)
                     .background(
                         store.selectedPeriod == period
                         ? Color.Primary.primary50

--- a/Projects/Feature/SelfStudyCheck/Sources/SelfStudyCheckReducer.swift
+++ b/Projects/Feature/SelfStudyCheck/Sources/SelfStudyCheckReducer.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ComposableArchitecture
 import SelfStudyCheckDomainInterface
 import Combine
@@ -16,6 +17,8 @@ public struct SelfStudyCheckReducer: Reducer {
     }
 
     public enum Period: Int, CaseIterable, Equatable {
+        case sixth = 6
+        case seventh = 7
         case eighth = 8
         case ninth = 9
         case tenth = 10
@@ -47,6 +50,7 @@ public struct SelfStudyCheckReducer: Reducer {
     public struct State: Equatable {
         public var studentItems: [StudentItem] = []
         public var initialStudentItems: [StudentItem] = []
+        public var periods: [Period] = [.eighth, .ninth, .tenth]
         public var selectedPeriod: Period = .eighth
         public var selectedGrade: Int = 1
         public var selectedClass: Int = 1
@@ -57,7 +61,15 @@ public struct SelfStudyCheckReducer: Reducer {
             studentItems != initialStudentItems
         }
 
-        public init() {}
+        public init(isFriday: Bool = Calendar.current.component(.weekday, from: Date()) == 6) {
+            if isFriday {
+                self.periods = [.sixth, .seventh, .eighth, .ninth, .tenth]
+                self.selectedPeriod = .sixth
+            } else {
+                self.periods = [.eighth, .ninth, .tenth]
+                self.selectedPeriod = .eighth
+            }
+        }
     }
 
     public enum Action {

--- a/Projects/Feature/SelfStudyCheck/Tests/SelfStudyCheckTests.swift
+++ b/Projects/Feature/SelfStudyCheck/Tests/SelfStudyCheckTests.swift
@@ -157,10 +157,16 @@ final class SelfStudyCheckTests: XCTestCase {
         XCTAssertFalse(store.state.isChanged)
     }
 
+    func testInitialState_OnFriday_IncludesSixthAndSeventhPeriods() async {
+        let store = makeStore(initialState: .init(isFriday: true))
+        XCTAssertEqual(store.state.periods, [.sixth, .seventh, .eighth, .ninth, .tenth])
+        XCTAssertEqual(store.state.selectedPeriod, .sixth)
+    }
+
     private func makeStore(
         attendanceUseCase: any GetStudentAttendanceUseCase = GetStudentAttendanceUseCaseSpy(),
         saveUseCase: any SaveAttendanceUseCase = SaveAttendanceUseCaseSpy(),
-        initialState: SelfStudyCheckReducer.State = .init()
+        initialState: SelfStudyCheckReducer.State = .init(isFriday: false)
     ) -> TestStore<SelfStudyCheckReducer.State, SelfStudyCheckReducer.Action> {
         TestStore(initialState: initialState) {
             SelfStudyCheckReducer(


### PR DESCRIPTION
## 개요
금요일 자습 출결 교시(6, 7) 추가

## 작업사항
금요일 자습 출결 교시(6, 7) 추가

## UI
<img width="145" height="314" alt="Simulator Screenshot - iPhone 17 - 2026-07-02 at 12 14 16" src="https://github.com/user-attachments/assets/52a56b9b-29a5-4f1a-b6a8-7a7057a526be" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 금요일에는 6·7번째 기간이 추가되어 선택 가능한 기간이 늘어났습니다.
  * 기간 선택 UI를 가로 스크롤 버튼 형태로 개선해 원하는 기간을 더 쉽게 탐색할 수 있습니다.
  * 기간 전환 시 애니메이션을 더 자연스럽게 다듬었습니다.
* **Bug Fixes**
  * 금요일인 경우 기본 선택 기간이 올바르게 설정되도록 개선했습니다.
* **Tests**
  * 금요일 초기 상태에서 기간 포함 여부와 기본 선택 값을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->